### PR TITLE
Fix dependency name for FAT filesystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# ESP-IDF build artifacts
+build/
+*.bin
+*.elf
+*.map
+*.log
+
+# SDK configuration
+sdkconfig
+sdkconfig.old
+
+# Editor folders
+.vscode/
+.idea/
+
+# Python cache
+__pycache__/
+*.pyc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.5)
+
+# Enregistre les composants personnalisés situés 
+# directement dans le dépôt (drivers, modules, ui)
+set(EXTRA_COMPONENT_DIRS
+    ${CMAKE_CURRENT_LIST_DIR}/drivers
+    ${CMAKE_CURRENT_LIST_DIR}/modules
+    ${CMAKE_CURRENT_LIST_DIR}/ui)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(waveshare_touch)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
+# Projet ESP-IDF pour écrans Waveshare ESP32-S3 Touch LCD
 
+Ce projet fournit une structure de base modulaire compatible avec les écrans Waveshare 5B (1024x600) et 7 (800x480) équipés d'un contrôleur tactile GT911.
+
+## Compilation et flashage
+
+1. Installer l'ESP-IDF conformément à la documentation officielle.
+2. Initialiser l'environnement : `source $IDF_PATH/export.sh`.
+3. Compiler le projet :
+   ```bash
+   idf.py build
+   ```
+4. Flasher sur la carte :
+   ```bash
+   idf.py -p /dev/ttyUSB0 flash monitor
+   ```
+
+## Structure
+
+- `drivers/` : pilotes UART, Wi-Fi, BLE, I2C, CAN, RS485.
+- `modules/` : détection d'écran, carte SD, gestion batterie.
+- `ui/` : interface graphique LVGL adaptative.
+- `main/` : point d'entrée du firmware.
+
+Chaque fichier contient des commentaires détaillés en français pour faciliter l'extension du projet.
+
+> **Note :** les pilotes et modules fournis sont des *squelettes* à compléter pour obtenir un firmware fonctionnel.
+
+## Licence
+
+Ce projet est distribué sous licence MIT. Consultez le fichier `LICENSE` pour plus de détails.
+
+## Bonnes pratiques de commit
+
+- Utilisez un message court et impératif décrivant la modification.
+- Ajoutez des explications plus longues dans le corps du message si nécessaire.

--- a/drivers/CMakeLists.txt
+++ b/drivers/CMakeLists.txt
@@ -1,0 +1,9 @@
+idf_component_register(SRCS
+    "uart_driver.c"
+    "wifi_driver.c"
+    "ble_driver.c"
+    "i2c_driver.c"
+    "can_driver.c"
+    "rs485_driver.c"
+    INCLUDE_DIRS "."
+    REQUIRES nvs_flash esp_wifi esp_event esp_netif bt driver)

--- a/drivers/ble_driver.c
+++ b/drivers/ble_driver.c
@@ -1,0 +1,34 @@
+#include "ble_driver.h"
+#include "esp_bt.h"
+#include "nvs_flash.h"
+#include <esp_gap_ble_api.h>
+#include "esp_bt_main.h"
+#include <esp_log.h>
+
+static const char *TAG = "ble";
+
+static esp_ble_adv_data_t adv_data = {
+    .set_scan_rsp = false,
+    .include_name = true,
+    .include_txpower = true,
+};
+
+void ble_driver_init(void) {
+    ESP_ERROR_CHECK(nvs_flash_init());
+    esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT);
+    esp_bt_controller_config_t bt_cfg = BT_CONTROLLER_INIT_CONFIG_DEFAULT();
+    ESP_ERROR_CHECK(esp_bt_controller_init(&bt_cfg));
+    ESP_ERROR_CHECK(esp_bt_controller_enable(ESP_BT_MODE_BLE));
+    ESP_ERROR_CHECK(esp_bluedroid_init());
+    ESP_ERROR_CHECK(esp_bluedroid_enable());
+
+    ESP_ERROR_CHECK(esp_ble_gap_config_adv_data(&adv_data));
+    ESP_ERROR_CHECK(esp_ble_gap_start_advertising(&(esp_ble_adv_params_t){
+        .adv_int_min = 0x20,
+        .adv_int_max = 0x40,
+        .adv_type = ADV_TYPE_IND,
+        .own_addr_type = BLE_ADDR_TYPE_PUBLIC,
+    }));
+
+    ESP_LOGI(TAG, "BLE publicité démarrée");
+}

--- a/drivers/ble_driver.h
+++ b/drivers/ble_driver.h
@@ -1,0 +1,5 @@
+#pragma once
+#include <esp_gap_ble_api.h>
+
+// Initialisation BLE simple
+void ble_driver_init(void);

--- a/drivers/can_driver.c
+++ b/drivers/can_driver.c
@@ -1,0 +1,12 @@
+#include "can_driver.h"
+#include <esp_log.h>
+
+void can_driver_init(void) {
+    twai_general_config_t g_config = TWAI_GENERAL_CONFIG_DEFAULT(GPIO_NUM_5, GPIO_NUM_4, TWAI_MODE_NORMAL);
+    twai_timing_config_t t_config = TWAI_TIMING_CONFIG_500KBITS();
+    twai_filter_config_t f_config = TWAI_FILTER_CONFIG_ACCEPT_ALL();
+
+    ESP_ERROR_CHECK(twai_driver_install(&g_config, &t_config, &f_config));
+    ESP_ERROR_CHECK(twai_start());
+    ESP_LOGI("can", "Bus CAN initialisé");
+}

--- a/drivers/can_driver.h
+++ b/drivers/can_driver.h
@@ -1,0 +1,5 @@
+#pragma once
+#include <driver/twai.h>
+
+// Initialisation du bus CAN
+void can_driver_init(void);

--- a/drivers/i2c_driver.c
+++ b/drivers/i2c_driver.c
@@ -1,0 +1,33 @@
+#include "i2c_driver.h"
+#include <esp_log.h>
+#include <driver/gpio.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+void i2c_driver_init(i2c_port_t port, int sda, int scl, uint32_t freq) {
+    i2c_config_t conf = {
+        .mode = I2C_MODE_MASTER,
+        .sda_io_num = sda,
+        .scl_io_num = scl,
+        .sda_pullup_en = GPIO_PULLUP_ENABLE,
+        .scl_pullup_en = GPIO_PULLUP_ENABLE,
+        .master.clk_speed = freq,
+    };
+    ESP_ERROR_CHECK(i2c_param_config(port, &conf));
+    ESP_ERROR_CHECK(i2c_driver_install(port, conf.mode, 0, 0, 0));
+    ESP_LOGI("i2c", "Bus I2C initialis\xC3\xA9");
+}
+
+void i2c_driver_scan(i2c_port_t port) {
+    for (uint8_t addr = 1; addr < 0x7F; ++addr) {
+        i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+        i2c_master_start(cmd);
+        i2c_master_write_byte(cmd, (addr << 1) | I2C_MASTER_WRITE, true);
+        i2c_master_stop(cmd);
+        esp_err_t ret = i2c_master_cmd_begin(port, cmd, pdMS_TO_TICKS(50));
+        i2c_cmd_link_delete(cmd);
+        if (ret == ESP_OK) {
+            ESP_LOGI("i2c", "Périphérique détecté à 0x%02X", addr);
+        }
+    }
+}

--- a/drivers/i2c_driver.h
+++ b/drivers/i2c_driver.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <driver/i2c.h>
+
+// Initialisation du bus I2C
+void i2c_driver_init(i2c_port_t port, int sda, int scl, uint32_t freq);
+
+// Scan I2C et affichage des adresses détectées
+void i2c_driver_scan(i2c_port_t port);

--- a/drivers/rs485_driver.c
+++ b/drivers/rs485_driver.c
@@ -1,0 +1,19 @@
+#include "rs485_driver.h"
+#include <driver/gpio.h>
+
+void rs485_driver_init(uart_port_t uart_num, int tx_pin, int rx_pin, int de_pin, int baudrate) {
+    uart_config_t config = {
+        .baud_rate = baudrate,
+        .data_bits = UART_DATA_8_BITS,
+        .parity = UART_PARITY_DISABLE,
+        .stop_bits = UART_STOP_BITS_1,
+        .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
+    };
+
+    ESP_ERROR_CHECK(uart_driver_install(uart_num, 256, 0, 0, NULL, 0));
+    ESP_ERROR_CHECK(uart_param_config(uart_num, &config));
+    ESP_ERROR_CHECK(uart_set_pin(uart_num, tx_pin, rx_pin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE));
+
+    gpio_set_direction(de_pin, GPIO_MODE_OUTPUT);
+    uart_set_mode(uart_num, UART_MODE_RS485_HALF_DUPLEX);
+}

--- a/drivers/rs485_driver.h
+++ b/drivers/rs485_driver.h
@@ -1,0 +1,5 @@
+#pragma once
+#include <driver/uart.h>
+
+// Communication RS485 en demi-duplex
+void rs485_driver_init(uart_port_t uart_num, int tx_pin, int rx_pin, int de_pin, int baudrate);

--- a/drivers/uart_driver.c
+++ b/drivers/uart_driver.c
@@ -1,0 +1,16 @@
+#include "uart_driver.h"
+#include <esp_log.h>
+
+void uart_driver_init(uart_port_t uart_num, int tx_pin, int rx_pin, int baudrate) {
+    uart_config_t config = {
+        .baud_rate = baudrate,
+        .data_bits = UART_DATA_8_BITS,
+        .parity = UART_PARITY_DISABLE,
+        .stop_bits = UART_STOP_BITS_1,
+        .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
+    };
+
+    ESP_ERROR_CHECK(uart_driver_install(uart_num, 256, 0, 0, NULL, 0));
+    ESP_ERROR_CHECK(uart_param_config(uart_num, &config));
+    ESP_ERROR_CHECK(uart_set_pin(uart_num, tx_pin, rx_pin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE));
+}

--- a/drivers/uart_driver.h
+++ b/drivers/uart_driver.h
@@ -1,0 +1,5 @@
+#pragma once
+#include <driver/uart.h>
+
+// Initialisation UART avec paramètres configurables
+void uart_driver_init(uart_port_t uart_num, int tx_pin, int rx_pin, int baudrate);

--- a/drivers/wifi_driver.c
+++ b/drivers/wifi_driver.c
@@ -1,0 +1,85 @@
+#include "wifi_driver.h"
+#include <esp_event.h>
+#include <esp_log.h>
+#include <esp_netif.h>
+#include <nvs_flash.h>
+#include <nvs.h>
+#include <string.h>
+#include <stdlib.h>
+
+static const char *TAG = "wifi";
+
+void wifi_driver_init(void) {
+    // Initialisation NVS pour stocker la configuration Wi-Fi
+    esp_err_t ret = nvs_flash_init();
+    if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+        ESP_ERROR_CHECK(nvs_flash_erase());
+        ESP_ERROR_CHECK(nvs_flash_init());
+    }
+
+    ESP_ERROR_CHECK(esp_netif_init());
+    ESP_ERROR_CHECK(esp_event_loop_create_default());
+    esp_netif_create_default_wifi_sta();
+
+    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+    ESP_ERROR_CHECK(esp_wifi_init(&cfg));
+    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
+    ESP_ERROR_CHECK(esp_wifi_start());
+
+    ESP_LOGI(TAG, "Wi-Fi initialisé en mode STA");
+}
+
+static void save_credentials(const char *ssid, const char *pass)
+{
+    nvs_handle_t handle;
+    if (nvs_open("wifi", NVS_READWRITE, &handle) == ESP_OK) {
+        nvs_set_str(handle, "ssid", ssid);
+        nvs_set_str(handle, "pass", pass);
+        nvs_commit(handle);
+        nvs_close(handle);
+    }
+}
+
+esp_err_t wifi_driver_connect(const char *new_ssid, const char *new_pass) {
+    nvs_handle_t handle;
+    char ssid[32] = "";
+    char pass[64] = "";
+
+    if (new_ssid && new_pass) {
+        strncpy(ssid, new_ssid, sizeof(ssid) - 1);
+        strncpy(pass, new_pass, sizeof(pass) - 1);
+        save_credentials(ssid, pass);
+    } else if (nvs_open("wifi", NVS_READONLY, &handle) == ESP_OK) {
+        size_t len = sizeof(ssid);
+        nvs_get_str(handle, "ssid", ssid, &len);
+        len = sizeof(pass);
+        nvs_get_str(handle, "pass", pass, &len);
+        nvs_close(handle);
+    }
+
+    wifi_config_t cfg = {0};
+    strncpy((char *)cfg.sta.ssid, ssid, sizeof(cfg.sta.ssid));
+    strncpy((char *)cfg.sta.password, pass, sizeof(cfg.sta.password));
+    esp_err_t err = esp_wifi_set_config(WIFI_IF_STA, &cfg);
+    if (err != ESP_OK) return err;
+
+    err = esp_wifi_scan_start(NULL, true);
+    if (err != ESP_OK) return err;
+    uint16_t ap_num = 0;
+    err = esp_wifi_scan_get_ap_num(&ap_num);
+    if (err != ESP_OK) return err;
+    if (ap_num > 0) {
+        wifi_ap_record_t *recs = calloc(ap_num, sizeof(wifi_ap_record_t));
+        if (esp_wifi_scan_get_ap_records(&ap_num, recs) == ESP_OK) {
+            for (int i = 0; i < ap_num; ++i) {
+                ESP_LOGI(TAG, "AP détecté: %s", recs[i].ssid);
+            }
+        }
+        free(recs);
+    }
+
+    err = esp_wifi_connect();
+    if (err != ESP_OK) return err;
+    ESP_LOGI(TAG, "Connexion au réseau %s", ssid);
+    return ESP_OK;
+}

--- a/drivers/wifi_driver.h
+++ b/drivers/wifi_driver.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <esp_wifi.h>
+#include <esp_err.h>
+
+// Initialisation de la pile Wi-Fi
+void wifi_driver_init(void);
+
+// Connexion en utilisant les identifiants fournis ou ceux stockés en NVS.
+// Si ssid et pass ne sont pas NULL, ils sont sauvegardés en NVS.
+// Retourne ESP_OK si la connexion a réussi
+esp_err_t wifi_driver_connect(const char *ssid, const char *pass);

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "main.c" INCLUDE_DIRS "." \
+                       REQUIRES drivers modules ui)

--- a/main/main.c
+++ b/main/main.c
@@ -1,0 +1,72 @@
+#include "uart_driver.h"
+#include "wifi_driver.h"
+#include "ble_driver.h"
+#include "i2c_driver.h"
+#include "can_driver.h"
+#include "rs485_driver.h"
+#include "screen_detect.h"
+#include "sd_card.h"
+#include "battery.h"
+#include "ui.h"
+#include <lvgl.h>
+#include "esp_timer.h"
+#include <string.h>
+#include <stdlib.h>
+
+// Tampon simulant le framebuffer LCD
+static lv_color_t *lcd_buffer;
+
+static void my_flush(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color_p)
+{
+    int32_t w = area->x2 - area->x1 + 1;
+    for (int y = area->y1; y <= area->y2; y++) {
+        memcpy(&lcd_buffer[y * drv->hor_res + area->x1], color_p, w * sizeof(lv_color_t));
+        color_p += w;
+    }
+    lv_disp_flush_ready(drv);
+}
+
+void app_main(void) {
+    // Initialisation LVGL
+    lv_init();
+
+    // Initialisation des pilotes
+    uart_driver_init(UART_NUM_0, 1, 3, 115200);
+    wifi_driver_init();
+    wifi_driver_connect(NULL, NULL);
+    ble_driver_init();
+    i2c_driver_init(I2C_NUM_0, 6, 7, 400000);
+    i2c_driver_scan(I2C_NUM_0);
+    can_driver_init();
+    rs485_driver_init(UART_NUM_1, 10, 9, 8, 9600);
+
+    // Modules
+    screen_detect_init();
+    size_t buf_size = screen_get_width() * screen_get_height() * sizeof(lv_color_t);
+    lcd_buffer = malloc(buf_size);
+
+    // Configuration simple du driver d'affichage
+    static lv_disp_draw_buf_t draw_buf;
+    static lv_color_t buf1[LV_HOR_RES_MAX * 40];
+    lv_disp_draw_buf_init(&draw_buf, buf1, NULL, LV_HOR_RES_MAX * 40);
+
+    lv_disp_drv_t disp_drv;
+    lv_disp_drv_init(&disp_drv);
+    disp_drv.hor_res = screen_get_width();
+    disp_drv.ver_res = screen_get_height();
+    disp_drv.flush_cb = my_flush;
+    disp_drv.draw_buf = &draw_buf;
+    lv_disp_drv_register(&disp_drv);
+
+    sd_card_init();
+    battery_update();
+
+    // Interface utilisateur
+    ui_init();
+
+    // Boucle principale pour LVGL
+    while (1) {
+        lv_timer_handler();
+        vTaskDelay(pdMS_TO_TICKS(5));
+    }
+}

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -1,0 +1,6 @@
+idf_component_register(SRCS
+    "screen_detect.c"
+    "sd_card.c"
+    "battery.c"
+    INCLUDE_DIRS "."
+    REQUIRES drivers lvgl fatfs sdmmc wear_levelling)

--- a/modules/battery.c
+++ b/modules/battery.c
@@ -1,0 +1,18 @@
+#include "battery.h"
+#include <driver/adc.h>
+#include <esp_log.h>
+
+static const char *TAG = "battery";
+static int s_battery_percent = 0;
+
+void battery_update(void) {
+    adc1_config_width(ADC_WIDTH_BIT_12);
+    adc1_config_channel_atten(ADC1_CHANNEL_0, ADC_ATTEN_DB_11);
+    int raw = adc1_get_raw(ADC1_CHANNEL_0);
+    s_battery_percent = (raw * 100) / 4095;
+    ESP_LOGI(TAG, "Niveau batterie: %d%%", s_battery_percent);
+}
+
+int battery_get_percent(void) {
+    return s_battery_percent;
+}

--- a/modules/battery.h
+++ b/modules/battery.h
@@ -1,0 +1,7 @@
+#pragma once
+
+// Met à jour la mesure de la batterie
+void battery_update(void);
+
+// Retourne le niveau de batterie en pourcentage (0-100)
+int battery_get_percent(void);

--- a/modules/screen_detect.c
+++ b/modules/screen_detect.c
@@ -1,0 +1,34 @@
+#include "screen_detect.h"
+#include "i2c_driver.h"
+#include <esp_log.h>
+#include <lvgl.h>
+#include <driver/gpio.h>
+#include <stdbool.h>
+
+static const char *TAG = "screen";
+static int s_width = 800;
+static int s_height = 480;
+
+void screen_detect_init(void) {
+    // Exemple simplifié : détection par lecture d'une GPIO
+    bool is_lcd5b = gpio_get_level(GPIO_NUM_2); // Hypothétique pin de détection
+
+    if (is_lcd5b) {
+        ESP_LOGI(TAG, "Écran 1024x600 détecté");
+        s_width = 1024;
+        s_height = 600;
+    } else {
+        ESP_LOGI(TAG, "Écran 800x480 détecté");
+        s_width = 800;
+        s_height = 480;
+    }
+    lv_disp_set_resolution(NULL, s_width, s_height);
+}
+
+int screen_get_width(void) {
+    return s_width;
+}
+
+int screen_get_height(void) {
+    return s_height;
+}

--- a/modules/screen_detect.h
+++ b/modules/screen_detect.h
@@ -1,0 +1,10 @@
+#pragma once
+
+// Détection automatique du type d'écran connecté
+void screen_detect_init(void);
+
+// Retourne la largeur détectée
+int screen_get_width(void);
+
+// Retourne la hauteur détectée
+int screen_get_height(void);

--- a/modules/sd_card.c
+++ b/modules/sd_card.c
@@ -1,0 +1,22 @@
+#include "sd_card.h"
+#include <esp_vfs_fat.h>
+#include <sdmmc_cmd.h>
+#include <esp_log.h>
+
+static const char *TAG = "sd";
+
+void sd_card_init(void) {
+    sdmmc_host_t host = SDMMC_HOST_DEFAULT();
+    sdmmc_slot_config_t slot_config = SDMMC_SLOT_CONFIG_DEFAULT();
+    esp_vfs_fat_sdmmc_mount_config_t mount_config = {
+        .format_if_mount_failed = false,
+        .max_files = 5,
+    };
+    sdmmc_card_t *card;
+    esp_err_t ret = esp_vfs_fat_sdmmc_mount("/sdcard", &host, &slot_config, &mount_config, &card);
+    if (ret == ESP_OK) {
+        ESP_LOGI(TAG, "Carte SD montée");
+    } else {
+        ESP_LOGE(TAG, "Échec montage carte SD: %s", esp_err_to_name(ret));
+    }
+}

--- a/modules/sd_card.h
+++ b/modules/sd_card.h
@@ -1,0 +1,4 @@
+#pragma once
+
+// Gestion de la carte SD pour la lecture et l'écriture de fichiers
+void sd_card_init(void);

--- a/ui/CMakeLists.txt
+++ b/ui/CMakeLists.txt
@@ -1,0 +1,1 @@
+idf_component_register(SRCS "ui.c" INCLUDE_DIRS "." REQUIRES modules)

--- a/ui/ui.c
+++ b/ui/ui.c
@@ -1,0 +1,40 @@
+#include "ui.h"
+#include <lvgl.h>
+#include "battery.h"
+
+static lv_obj_t *bar_batt;
+
+static void battery_timer_cb(lv_timer_t *t)
+{
+    lv_bar_set_value(bar_batt, battery_get_percent(), LV_ANIM_OFF);
+}
+
+void ui_init(void) {
+    /* Conteneur principal adaptatif */
+    lv_obj_t *cont = lv_obj_create(lv_scr_act());
+    lv_obj_set_size(cont, LV_PCT(100), LV_PCT(100));
+    lv_obj_set_flex_flow(cont, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(cont, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+
+    /* Label de bienvenue */
+    lv_obj_t *label = lv_label_create(cont);
+    lv_label_set_text(label, "Interface prête");
+
+    /* Slider d'exemple */
+    lv_obj_t *slider = lv_slider_create(cont);
+    lv_obj_set_width(slider, LV_PCT(80));
+
+    /* Bouton simple */
+    lv_obj_t *btn = lv_btn_create(cont);
+    lv_obj_t *btn_label = lv_label_create(btn);
+    lv_label_set_text(btn_label, "OK");
+
+    /* Barre de niveau batterie */
+    bar_batt = lv_bar_create(cont);
+    lv_obj_set_width(bar_batt, LV_PCT(80));
+    lv_bar_set_range(bar_batt, 0, 100);
+    lv_bar_set_value(bar_batt, battery_get_percent(), LV_ANIM_OFF);
+
+    /* Rafraîchissement périodique du niveau batterie */
+    lv_timer_create(battery_timer_cb, 2000, NULL);
+}

--- a/ui/ui.h
+++ b/ui/ui.h
@@ -1,0 +1,4 @@
+#pragma once
+
+// Interface utilisateur LVGL adaptative
+void ui_init(void);


### PR DESCRIPTION
## Summary
- correct modules component to depend on `fatfs` instead of removed `esp_vfs_fat`

## Testing
- `idf.py set-target esp32s3` *(fails: idf.py not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68415e0464a083238d0c2087dc9e85bb