### PR TITLE
Add agent guide and setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Instructions pour Codex
+
+## Style de commit
+- Message court et à l'infinitif (ex. "Corriger bug")
+- Ajouter un corps de message si nécessaire pour expliquer les détails
+
+## Commandes de test
+- Lancer `idf.py build` pour vérifier la compilation
+
+## Script d'installation
+- Exécuter `./setup.sh` si les dépendances ESP-IDF ne sont pas présentes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Projet ESP-IDF pour écrans Waveshare ESP32-S3 Touch LCD
 
-Ce projet fournit une structure de base modulaire compatible avec les écrans Waveshare 5B (1024x600) et 7 (800x480) équipés d'un contrôleur tactile GT911.
+Ce projet fournit un squelette modulaire pour développer un firmware compatible avec les écrans Waveshare 5B (1024x600) et 7" (800x480) équipés du contrôleur tactile GT911.
 
 ## Compilation et flashage
 
@@ -15,16 +15,16 @@ Ce projet fournit une structure de base modulaire compatible avec les écrans Wa
    idf.py -p /dev/ttyUSB0 flash monitor
    ```
 
-## Structure
+## Architecture
 
-- `drivers/` : pilotes UART, Wi-Fi, BLE, I2C, CAN, RS485.
-- `modules/` : détection d'écran, carte SD, gestion batterie.
+- `main/` : point d'entrée du firmware et initialisation LVGL.
+- `drivers/` : pilotes de communication (UART, Wi-Fi, BLE, I2C, CAN, RS485).
+- `modules/` : fonctionnalités haut niveau (détection d'écran, carte SD, gestion batterie).
 - `ui/` : interface graphique LVGL adaptative.
-- `main/` : point d'entrée du firmware.
 
-Chaque fichier contient des commentaires détaillés en français pour faciliter l'extension du projet.
+Chaque composant est livré sous forme de squelette commenté en français afin de faciliter son extension.
 
-> **Note :** les pilotes et modules fournis sont des *squelettes* à compléter pour obtenir un firmware fonctionnel.
+> **Note :** les pilotes et modules fournis sont des exemples à compléter pour obtenir un firmware opérationnel.
 
 ## Licence
 
@@ -34,41 +34,3 @@ Ce projet est distribué sous licence MIT. Consultez le fichier `LICENSE` pour p
 
 - Utilisez un message court et impératif décrivant la modification.
 - Ajoutez des explications plus longues dans le corps du message si nécessaire.
-
-
-Ce projet fournit une structure de base modulaire compatible avec les écrans Waveshare 5B (1024x600) et 7 (800x480) équipés d'un contrôleur tactile GT911.
-
-## Compilation et flashage
-
-1. Installer l'ESP-IDF conformément à la documentation officielle.
-2. Initialiser l'environnement : `source $IDF_PATH/export.sh`.
-3. Compiler le projet :
-   ```bash
-   idf.py build
-   ```
-4. Flasher sur la carte :
-   ```bash
-   idf.py -p /dev/ttyUSB0 flash monitor
-   ```
-
-## Structure
-
-- `drivers/` : pilotes UART, Wi-Fi, BLE, I2C, CAN, RS485.
-- `modules/` : détection d'écran, carte SD, gestion batterie.
-- `ui/` : interface graphique LVGL adaptative.
-- `main/` : point d'entrée du firmware.
-
-Chaque fichier contient des commentaires détaillés en français pour faciliter l'extension du projet.
-
-
-> **Note :** les pilotes et modules fournis sont des *squelettes* à compléter pour obtenir un firmware fonctionnel.
-
-## Licence
-
-Ce projet est distribué sous licence MIT. Consultez le fichier `LICENSE` pour plus de détails.
-
-## Bonnes pratiques de commit
-
-- Utilisez un message court et impératif décrivant la modification.
-- Ajoutez des explications plus longues dans le corps du message si nécessaire.
-

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Script d'installation minimal pour ESP-IDF
+set -e
+
+if [ -z "$IDF_PATH" ]; then
+  echo "Clonage de l'ESP-IDF dans \$HOME/esp-idf" >&2
+  git clone --depth 1 https://github.com/espressif/esp-idf.git "$HOME/esp-idf"
+  export IDF_PATH="$HOME/esp-idf"
+  "$IDF_PATH/install.sh"
+fi
+
+source "$IDF_PATH/export.sh"


### PR DESCRIPTION
## Summary
- fix README duplication and document architecture
- add instructions for Codex in `AGENTS.md`
- provide simple ESP-IDF installation script

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841927ccf588323b05762ecdc35ae9c