### PR TITLE
Nettoyer pilotes et corriger main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Instructions pour Codex
+
+## Style de commit
+- Message court et à l'infinitif (ex. "Corriger bug")
+- Ajouter un corps de message si nécessaire pour expliquer les détails
+
+## Commandes de test
+- Lancer `idf.py build` pour vérifier la compilation
+
+## Script d'installation
+- Exécuter `./setup.sh` si les dépendances ESP-IDF ne sont pas présentes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Projet ESP-IDF pour écrans Waveshare ESP32-S3 Touch LCD
 
-Ce projet fournit une structure de base modulaire compatible avec les écrans Waveshare 5B (1024x600) et 7 (800x480) équipés d'un contrôleur tactile GT911.
+Ce projet fournit un squelette modulaire pour développer un firmware compatible avec les écrans Waveshare 5B (1024x600) et 7" (800x480) équipés du contrôleur tactile GT911.
 
 ## Compilation et flashage
 
@@ -15,16 +15,16 @@ Ce projet fournit une structure de base modulaire compatible avec les écrans Wa
    idf.py -p /dev/ttyUSB0 flash monitor
    ```
 
-## Structure
+## Architecture
 
-- `drivers/` : pilotes UART, Wi-Fi, BLE, I2C, CAN, RS485.
-- `modules/` : détection d'écran, carte SD, gestion batterie.
+- `main/` : point d'entrée du firmware et initialisation LVGL.
+- `drivers/` : pilotes de communication (UART, Wi-Fi, BLE, I2C, CAN, RS485).
+- `modules/` : fonctionnalités haut niveau (détection d'écran, carte SD, gestion batterie).
 - `ui/` : interface graphique LVGL adaptative.
-- `main/` : point d'entrée du firmware.
 
-Chaque fichier contient des commentaires détaillés en français pour faciliter l'extension du projet.
+Chaque composant est livré sous forme de squelette commenté en français afin de faciliter son extension.
 
-> **Note :** les pilotes et modules fournis sont des *squelettes* à compléter pour obtenir un firmware fonctionnel.
+> **Note :** les pilotes et modules fournis sont des exemples à compléter pour obtenir un firmware opérationnel.
 
 ## Licence
 
@@ -34,41 +34,3 @@ Ce projet est distribué sous licence MIT. Consultez le fichier `LICENSE` pour p
 
 - Utilisez un message court et impératif décrivant la modification.
 - Ajoutez des explications plus longues dans le corps du message si nécessaire.
-
-
-Ce projet fournit une structure de base modulaire compatible avec les écrans Waveshare 5B (1024x600) et 7 (800x480) équipés d'un contrôleur tactile GT911.
-
-## Compilation et flashage
-
-1. Installer l'ESP-IDF conformément à la documentation officielle.
-2. Initialiser l'environnement : `source $IDF_PATH/export.sh`.
-3. Compiler le projet :
-   ```bash
-   idf.py build
-   ```
-4. Flasher sur la carte :
-   ```bash
-   idf.py -p /dev/ttyUSB0 flash monitor
-   ```
-
-## Structure
-
-- `drivers/` : pilotes UART, Wi-Fi, BLE, I2C, CAN, RS485.
-- `modules/` : détection d'écran, carte SD, gestion batterie.
-- `ui/` : interface graphique LVGL adaptative.
-- `main/` : point d'entrée du firmware.
-
-Chaque fichier contient des commentaires détaillés en français pour faciliter l'extension du projet.
-
-
-> **Note :** les pilotes et modules fournis sont des *squelettes* à compléter pour obtenir un firmware fonctionnel.
-
-## Licence
-
-Ce projet est distribué sous licence MIT. Consultez le fichier `LICENSE` pour plus de détails.
-
-## Bonnes pratiques de commit
-
-- Utilisez un message court et impératif décrivant la modification.
-- Ajoutez des explications plus longues dans le corps du message si nécessaire.
-

--- a/drivers/rs485_driver.c
+++ b/drivers/rs485_driver.c
@@ -16,14 +16,4 @@ void rs485_driver_init(uart_port_t uart_num, int tx_pin, int rx_pin, int de_pin,
 
     gpio_set_direction(de_pin, GPIO_MODE_OUTPUT);
     uart_set_mode(uart_num, UART_MODE_RS485_HALF_DUPLEX);
-
-void rs485_driver_init(uart_port_t uart_num, int tx_pin, int rx_pin, int de_pin, int baudrate) {
-    // TODO: implémenter la gestion RS485
-    (void)uart_num;
-    (void)tx_pin;
-    (void)rx_pin;
-    (void)de_pin;
-    (void)baudrate;
-
-
 }

--- a/drivers/uart_driver.c
+++ b/drivers/uart_driver.c
@@ -12,13 +12,6 @@ void uart_driver_init(uart_port_t uart_num, int tx_pin, int rx_pin, int baudrate
 
     ESP_ERROR_CHECK(uart_driver_install(uart_num, 256, 0, 0, NULL, 0));
     ESP_ERROR_CHECK(uart_param_config(uart_num, &config));
-    ESP_ERROR_CHECK(uart_set_pin(uart_num, tx_pin, rx_pin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE));
-
-void uart_driver_init(uart_port_t uart_num, int tx_pin, int rx_pin, int baudrate) {
-    // TODO: implémenter l'initialisation UART
-    (void)uart_num;
-    (void)tx_pin;
-    (void)rx_pin;
-    (void)baudrate;
-
+    ESP_ERROR_CHECK(uart_set_pin(uart_num, tx_pin, rx_pin,
+                                 UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE));
 }

--- a/drivers/wifi_driver.c
+++ b/drivers/wifi_driver.c
@@ -10,7 +10,6 @@
 static const char *TAG = "wifi";
 
 void wifi_driver_init(void) {
-    // Initialisation NVS pour stocker la configuration Wi-Fi
     esp_err_t ret = nvs_flash_init();
     if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
         ESP_ERROR_CHECK(nvs_flash_erase());
@@ -26,11 +25,10 @@ void wifi_driver_init(void) {
     ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
     ESP_ERROR_CHECK(esp_wifi_start());
 
-    ESP_LOGI(TAG, "Wi-Fi initialisé en mode STA");
+    ESP_LOGI(TAG, "Wi-Fi initialis\xC3\xA9 en mode STA");
 }
 
-static void save_credentials(const char *ssid, const char *pass)
-{
+static void save_credentials(const char *ssid, const char *pass) {
     nvs_handle_t handle;
     if (nvs_open("wifi", NVS_READWRITE, &handle) == ESP_OK) {
         nvs_set_str(handle, "ssid", ssid);
@@ -41,23 +39,6 @@ static void save_credentials(const char *ssid, const char *pass)
 }
 
 esp_err_t wifi_driver_connect(const char *new_ssid, const char *new_pass) {
-
-static void save_credentials(const char *ssid, const char *pass)
-{
-    nvs_handle_t handle;
-    if (nvs_open("wifi", NVS_READWRITE, &handle) == ESP_OK) {
-        nvs_set_str(handle, "ssid", ssid);
-        nvs_set_str(handle, "pass", pass);
-        nvs_commit(handle);
-        nvs_close(handle);
-    }
-}
-
-void wifi_driver_connect(const char *new_ssid, const char *new_pass) {
-
-void wifi_driver_connect(const char *new_ssid, const char *new_pass) {
-void wifi_driver_connect(void) {
-
     nvs_handle_t handle;
     char ssid[32] = "";
     char pass[64] = "";
@@ -67,13 +48,14 @@ void wifi_driver_connect(void) {
         strncpy(pass, new_pass, sizeof(pass) - 1);
         save_credentials(ssid, pass);
     } else if (nvs_open("wifi", NVS_READONLY, &handle) == ESP_OK) {
-
-    if (nvs_open("wifi", NVS_READONLY, &handle) == ESP_OK) {
         size_t len = sizeof(ssid);
         nvs_get_str(handle, "ssid", ssid, &len);
         len = sizeof(pass);
         nvs_get_str(handle, "pass", pass, &len);
         nvs_close(handle);
+    } else {
+        ESP_LOGE(TAG, "Aucun identifiant Wi-Fi disponible");
+        return ESP_ERR_INVALID_STATE;
     }
 
     wifi_config_t cfg = {0};
@@ -84,33 +66,22 @@ void wifi_driver_connect(void) {
 
     err = esp_wifi_scan_start(NULL, true);
     if (err != ESP_OK) return err;
+
     uint16_t ap_num = 0;
     err = esp_wifi_scan_get_ap_num(&ap_num);
-    if (err != ESP_OK) return err;
-    ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &cfg));
-
-    ESP_ERROR_CHECK(esp_wifi_scan_start(NULL, true));
-    uint16_t ap_num = 0;
-    ESP_ERROR_CHECK(esp_wifi_scan_get_ap_num(&ap_num));
-    if (ap_num > 0) {
+    if (err == ESP_OK && ap_num > 0) {
         wifi_ap_record_t *recs = calloc(ap_num, sizeof(wifi_ap_record_t));
         if (esp_wifi_scan_get_ap_records(&ap_num, recs) == ESP_OK) {
             for (int i = 0; i < ap_num; ++i) {
-                ESP_LOGI(TAG, "AP détecté: %s", recs[i].ssid);
+                ESP_LOGI(TAG, "AP d\xC3\xA9tect\xC3\xA9: %s", recs[i].ssid);
             }
         }
         free(recs);
     }
 
     err = esp_wifi_connect();
-    if (err != ESP_OK) return err;
-    ESP_LOGI(TAG, "Connexion au réseau %s", ssid);
-    return ESP_OK;
+    if (err == ESP_OK) {
+        ESP_LOGI(TAG, "Connexion au r\xC3\xA9seau %s", ssid);
+    }
+    return err;
 }
-    ESP_ERROR_CHECK(esp_wifi_connect());
-    ESP_LOGI(TAG, "Connexion au réseau %s", ssid);
-
-
-void wifi_driver_init(void) {
-    // TODO: implémenter la configuration Wi-Fi STA et le scan
-

--- a/main/main.c
+++ b/main/main.c
@@ -13,7 +13,6 @@
 #include <string.h>
 #include <stdlib.h>
 
-// Tampon simulant le framebuffer LCD
 static lv_color_t *lcd_buffer;
 
 static void my_flush(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color_p)
@@ -23,56 +22,23 @@ static void my_flush(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *colo
         memcpy(&lcd_buffer[y * drv->hor_res + area->x1], color_p, w * sizeof(lv_color_t));
         color_p += w;
     }
-
-
-
-static void my_flush(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color_p)
-{
-    int32_t w = area->x2 - area->x1 + 1;
-    for (int y = area->y1; y <= area->y2; y++) {
-        memcpy(&lcd_buffer[y * drv->hor_res + area->x1], color_p, w * sizeof(lv_color_t));
-        color_p += w;
-    }
-
     lv_disp_flush_ready(drv);
 }
 
 void app_main(void) {
-    // Initialisation LVGL
     lv_init();
 
-    // Initialisation des pilotes
-    uart_driver_init(UART_NUM_0, 1, 3, 115200);
-    wifi_driver_init();
-    wifi_driver_connect(NULL, NULL);
-
-
-
-
-    i2c_driver_init(I2C_NUM_0, 6, 7, 400000);
-    ble_driver_init();
-    i2c_driver_init(I2C_NUM_0, 6, 7, 400000);
-    wifi_driver_connect();
-
-    size_t buf_size = screen_get_width() * screen_get_height() * sizeof(lv_color_t);
-    lcd_buffer = malloc(buf_size);
-void app_main(void) {
-    // Initialisation des pilotes
     uart_driver_init(UART_NUM_0, 1, 3, 115200);
     wifi_driver_init();
     ble_driver_init();
-
-
-    i2c_driver_scan(I2C_NUM_0);
+    i2c_driver_init(I2C_NUM_0, 6, 7, 400000);
     can_driver_init();
     rs485_driver_init(UART_NUM_1, 10, 9, 8, 9600);
 
-    // Modules
     screen_detect_init();
     size_t buf_size = screen_get_width() * screen_get_height() * sizeof(lv_color_t);
     lcd_buffer = malloc(buf_size);
 
-    // Configuration simple du driver d'affichage
     static lv_disp_draw_buf_t draw_buf;
     static lv_color_t buf1[LV_HOR_RES_MAX * 40];
     lv_disp_draw_buf_init(&draw_buf, buf1, NULL, LV_HOR_RES_MAX * 40);
@@ -86,14 +52,14 @@ void app_main(void) {
     lv_disp_drv_register(&disp_drv);
 
     sd_card_init();
+    wifi_driver_connect(NULL, NULL);
     battery_update();
-
-    // Interface utilisateur
     ui_init();
 
-    // Boucle principale pour LVGL
     while (1) {
         lv_timer_handler();
         vTaskDelay(pdMS_TO_TICKS(5));
     }
+
+    free(lcd_buffer);
 }

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Script d'installation minimal pour ESP-IDF
+set -e
+
+if [ -z "$IDF_PATH" ]; then
+  echo "Clonage de l'ESP-IDF dans \$HOME/esp-idf" >&2
+  git clone --depth 1 https://github.com/espressif/esp-idf.git "$HOME/esp-idf"
+  export IDF_PATH="$HOME/esp-idf"
+  "$IDF_PATH/install.sh"
+fi
+
+source "$IDF_PATH/export.sh"

--- a/ui/ui.c
+++ b/ui/ui.c
@@ -6,6 +6,7 @@ static lv_obj_t *bar_batt;
 
 static void battery_timer_cb(lv_timer_t *t)
 {
+    battery_update();
     lv_bar_set_value(bar_batt, battery_get_percent(), LV_ANIM_OFF);
 }
 


### PR DESCRIPTION
## Summary
- simplifié les pilotes UART/RS485/Wi-Fi
- réécrit `app_main` sans doublons
- rafraîchi la batterie dans `ui.c`

## Testing
- `./setup.sh` *(failed: certificate verify failed)*
- `idf.py build` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841927ccf588323b05762ecdc35ae9c