### PR TITLE
Fix docs and includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@ Ce projet fournit un squelette modulaire pour développer un firmware compatible
 ## Compilation et flashage
 
 1. Installer l'ESP-IDF conformément à la documentation officielle.
-2. Initialiser l'environnement : `source $IDF_PATH/export.sh`.
-3. Compiler le projet :
+2. Exécuter `./setup.sh` pour préparer l'environnement.
+3. Initialiser l'environnement : `source $IDF_PATH/export.sh`.
+4. Compiler le projet :
    ```bash
    idf.py build
    ```
-4. Flasher sur la carte :
+5. Flasher sur la carte :
    ```bash
    idf.py -p /dev/ttyUSB0 flash monitor
    ```

--- a/modules/screen_detect.c
+++ b/modules/screen_detect.c
@@ -22,7 +22,7 @@ void screen_detect_init(void) {
         s_width = 800;
         s_height = 480;
     }
-    lv_disp_set_resolution(NULL, s_width, s_height);
+    lv_display_set_resolution(NULL, s_width, s_height);
 }
 
 int screen_get_width(void) {

--- a/modules/sd_card.c
+++ b/modules/sd_card.c
@@ -1,6 +1,7 @@
 #include "sd_card.h"
 #include <esp_vfs_fat.h>
 #include <sdmmc_cmd.h>
+#include <driver/sdmmc_host.h>
 #include <esp_log.h>
 
 static const char *TAG = "sd";


### PR DESCRIPTION
## Summary
- add missing sdmmc include
- update LVGL API call
- document running `./setup.sh` before build

## Testing
- `python $HOME/esp-idf/tools/idf.py build` *(fails: No module named 'esp_idf_monitor')*

------
https://chatgpt.com/codex/tasks/task_e_6841b7703ab88323933d66dfdea6dbfe