### PR TITLE
Fix sdmmc include and LVGL API

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@ Ce projet fournit un squelette modulaire pour développer un firmware compatible
 ## Compilation et flashage
 
 1. Installer l'ESP-IDF conformément à la documentation officielle.
-2. Initialiser l'environnement : `source $IDF_PATH/export.sh`.
-3. Compiler le projet :
+2. Exécuter `./setup.sh` pour préparer l'environnement.
+3. Initialiser l'environnement : `source $IDF_PATH/export.sh`.
+4. Compiler le projet :
    ```bash
    idf.py build
    ```
-4. Flasher sur la carte :
+5. Flasher sur la carte :
    ```bash
    idf.py -p /dev/ttyUSB0 flash monitor
    ```

--- a/main/main.c
+++ b/main/main.c
@@ -1,6 +1,8 @@
 #include "uart_driver.h"
 #include "wifi_driver.h"
+#if CONFIG_BT_BLUEDROID_ENABLED
 #include "ble_driver.h"
+#endif
 #include "i2c_driver.h"
 #include "can_driver.h"
 #include "rs485_driver.h"
@@ -15,14 +17,17 @@
 
 static lv_color_t *lcd_buffer;
 
-static void my_flush(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color_p)
+static void my_flush(lv_display_t *disp, const lv_area_t *area, uint8_t *px_map)
 {
     int32_t w = area->x2 - area->x1 + 1;
-    for (int y = area->y1; y <= area->y2; y++) {
-        memcpy(&lcd_buffer[y * drv->hor_res + area->x1], color_p, w * sizeof(lv_color_t));
-        color_p += w;
+    int32_t h = area->y2 - area->y1 + 1;
+    int32_t hor_res = lv_display_get_horizontal_resolution(disp);
+    lv_color_t *color_p = (lv_color_t *)px_map;
+    for(int32_t y = 0; y < h; y++) {
+        memcpy(&lcd_buffer[(area->y1 + y) * hor_res + area->x1],
+               &color_p[y * w], w * sizeof(lv_color_t));
     }
-    lv_disp_flush_ready(drv);
+    lv_display_flush_ready(disp);
 }
 
 void app_main(void) {
@@ -30,7 +35,9 @@ void app_main(void) {
 
     uart_driver_init(UART_NUM_0, 1, 3, 115200);
     wifi_driver_init();
+#if CONFIG_BT_BLUEDROID_ENABLED
     ble_driver_init();
+#endif
     i2c_driver_init(I2C_NUM_0, 6, 7, 400000);
     can_driver_init();
     rs485_driver_init(UART_NUM_1, 10, 9, 8, 9600);
@@ -39,17 +46,13 @@ void app_main(void) {
     size_t buf_size = screen_get_width() * screen_get_height() * sizeof(lv_color_t);
     lcd_buffer = malloc(buf_size);
 
-    static lv_disp_draw_buf_t draw_buf;
-    static lv_color_t buf1[LV_HOR_RES_MAX * 40];
-    lv_disp_draw_buf_init(&draw_buf, buf1, NULL, LV_HOR_RES_MAX * 40);
-
-    lv_disp_drv_t disp_drv;
-    lv_disp_drv_init(&disp_drv);
-    disp_drv.hor_res = screen_get_width();
-    disp_drv.ver_res = screen_get_height();
-    disp_drv.flush_cb = my_flush;
-    disp_drv.draw_buf = &draw_buf;
-    lv_disp_drv_register(&disp_drv);
+    uint32_t width = screen_get_width();
+    uint32_t height = screen_get_height();
+    lv_color_t *buf1 = malloc(width * 40 * sizeof(lv_color_t));
+    lv_display_t *disp = lv_display_create(width, height);
+    lv_display_set_flush_cb(disp, my_flush);
+    lv_display_set_buffers(disp, buf1, NULL, width * 40 * sizeof(lv_color_t),
+                           LV_DISPLAY_RENDER_MODE_PARTIAL);
 
     sd_card_init();
     wifi_driver_connect(NULL, NULL);
@@ -61,5 +64,6 @@ void app_main(void) {
         vTaskDelay(pdMS_TO_TICKS(5));
     }
 
+    free(buf1);
     free(lcd_buffer);
 }

--- a/modules/screen_detect.c
+++ b/modules/screen_detect.c
@@ -22,7 +22,7 @@ void screen_detect_init(void) {
         s_width = 800;
         s_height = 480;
     }
-    lv_disp_set_resolution(NULL, s_width, s_height);
+    lv_display_set_resolution(NULL, s_width, s_height);
 }
 
 int screen_get_width(void) {

--- a/modules/sd_card.c
+++ b/modules/sd_card.c
@@ -1,6 +1,7 @@
 #include "sd_card.h"
 #include <esp_vfs_fat.h>
 #include <sdmmc_cmd.h>
+#include <driver/sdmmc_host.h>
 #include <esp_log.h>
 
 static const char *TAG = "sd";


### PR DESCRIPTION
## Summary
- include sdmmc_host header
- update screen resolution call for new LVGL API
- port main.c to LVGL 9

## Testing
- `idf.py build` *(fails: submodule initialization takes too long)*

------
https://chatgpt.com/codex/tasks/task_e_6841b7703ab88323933d66dfdea6dbfe