### PR TITLE
Add Waveshare LCD driver and document components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,3 @@ sdkconfig.old
 __pycache__/
 *.pyc
 dependencies.lock
-components/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 
-# Enregistre les composants personnalisés situés 
+# Enregistre les composants personnalisés situés
 # directement dans le dépôt (drivers, modules, ui)
 set(EXTRA_COMPONENT_DIRS
     ${CMAKE_CURRENT_LIST_DIR}/drivers

--- a/README.md
+++ b/README.md
@@ -26,10 +26,11 @@ Ce projet fournit un squelette modulaire pour développer un firmware compatible
 - `drivers/` : pilotes de communication (UART, Wi-Fi, BLE, I2C, CAN, RS485).
 - `modules/` : fonctionnalités haut niveau (détection d'écran, carte SD, gestion batterie).
 - `ui/` : interface graphique LVGL adaptative.
+- `components/` : contient LVGL après exécution de `./setup.sh`.
 
 Chaque composant est livré sous forme de squelette commenté en français afin de faciliter son extension.
 
-> **Note :** les pilotes et modules fournis sont des exemples à compléter pour obtenir un firmware opérationnel. La fonction `my_flush()` dans `main/main.c` se contente de copier les pixels dans un tampon. Pour voir l'interface sur l'écran, implémentez un pilote `esp_lcd` adapté au panneau Waveshare.
+> **Note :** les pilotes et modules fournis sont des exemples à compléter pour obtenir un firmware opérationnel. Un pilote `esp_lcd` minimal pour les écrans Waveshare est fourni dans `drivers/lcd_panel_waveshare.c`.
 
 ## Licence
 

--- a/components/README.md
+++ b/components/README.md
@@ -1,0 +1,1 @@
+Ce dossier contiendra LVGL une fois setup.sh exécuté.

--- a/drivers/CMakeLists.txt
+++ b/drivers/CMakeLists.txt
@@ -4,8 +4,9 @@ set(srcs
     i2c_driver.c
     can_driver.c
     rs485_driver.c
+    lcd_panel_waveshare.c
 )
-set(requires nvs_flash esp_wifi esp_event esp_netif driver)
+set(requires nvs_flash esp_wifi esp_event esp_netif driver esp_lcd)
 set(priv_requires)
 set(include_dirs .)
 

--- a/drivers/lcd_panel_waveshare.c
+++ b/drivers/lcd_panel_waveshare.c
@@ -1,0 +1,48 @@
+#include "lcd_panel_waveshare.h"
+#include <esp_lcd_panel_io.h>
+#include <esp_lcd_panel_vendor.h>
+#include <esp_log.h>
+
+#define PIN_NUM_PCLK  40
+#define PIN_NUM_CS    41
+#define PIN_NUM_DE    42
+#define PIN_NUM_VSYNC 39
+#define PIN_NUM_HSYNC 38
+#define PIN_NUM_DATA0 0
+
+static const char *TAG = "lcd_panel";
+
+esp_lcd_panel_handle_t lcd_panel_waveshare_init(int width, int height) {
+    esp_lcd_rgb_panel_config_t panel_config = {
+        .data_width = 16,
+        .psram_trans_align = 64,
+        .num_fbs = 1,
+        .clk_src = LCD_CLK_SRC_DEFAULT,
+        .disp_gpio_num = PIN_NUM_DE,
+        .pclk_gpio_num = PIN_NUM_PCLK,
+        .vsync_gpio_num = PIN_NUM_VSYNC,
+        .hsync_gpio_num = PIN_NUM_HSYNC,
+        .data_gpio_nums = {
+            PIN_NUM_DATA0, PIN_NUM_DATA0 + 1, PIN_NUM_DATA0 + 2, PIN_NUM_DATA0 + 3,
+            PIN_NUM_DATA0 + 4, PIN_NUM_DATA0 + 5, PIN_NUM_DATA0 + 6, PIN_NUM_DATA0 + 7,
+            PIN_NUM_DATA0 + 8, PIN_NUM_DATA0 + 9, PIN_NUM_DATA0 + 10, PIN_NUM_DATA0 + 11,
+            PIN_NUM_DATA0 + 12, PIN_NUM_DATA0 + 13, PIN_NUM_DATA0 + 14, PIN_NUM_DATA0 + 15
+        },
+        .timings = {
+            .pclk_hz = 9 * 1000 * 1000,
+            .h_res = width,
+            .v_res = height,
+        }
+    };
+
+    esp_lcd_panel_handle_t handle = NULL;
+    esp_err_t ret = esp_lcd_new_rgb_panel(&panel_config, &handle);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Erreur initialisation panneau %d", ret);
+        return NULL;
+    }
+    esp_lcd_panel_reset(handle);
+    esp_lcd_panel_init(handle);
+    esp_lcd_panel_invert_color(handle, true);
+    return handle;
+}

--- a/drivers/lcd_panel_waveshare.h
+++ b/drivers/lcd_panel_waveshare.h
@@ -1,0 +1,6 @@
+#pragma once
+#include <esp_lcd_panel_ops.h>
+#include <stdint.h>
+
+// Initialise le panneau LCD Waveshare et renvoie le handle
+esp_lcd_panel_handle_t lcd_panel_waveshare_init(int width, int height);

--- a/main/main.c
+++ b/main/main.c
@@ -9,6 +9,7 @@
 #include "screen_detect.h"
 #include "sd_card.h"
 #include "battery.h"
+#include "lcd_panel_waveshare.h"
 #include "ui.h"
 #include <lvgl.h>
 #include "esp_lcd_panel_ops.h"
@@ -71,6 +72,8 @@ void app_main(void) {
 
     uint32_t width = screen_get_width();
     uint32_t height = screen_get_height();
+
+    s_panel = lcd_panel_waveshare_init(width, height);
 
     lv_display_t *disp = lv_display_create(width, height);
     lv_display_set_flush_cb(disp, my_flush);

--- a/modules/screen_detect.c
+++ b/modules/screen_detect.c
@@ -25,8 +25,8 @@ void screen_detect_init(void) {
     }
 
     /*
-     * LVGL v9 ne fournit pas d'API pour modifier la resolution d'un ecran
-     * deja enregistree. La taille sera donc renseignee lors de
+     * LVGL v9 ne fournit pas d'API pour modifier la résolution d'un écran
+     * déjà enregistrée. La taille sera donc renseignée lors de
      * l'initialisation du pilote dans main.c.
      */
 


### PR DESCRIPTION
## Summary
- add minimal esp_lcd driver for Waveshare screens
- register it in CMake and call from `app_main`
- document `components/` directory and new driver
- keep example components directory under version control

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684332086c5883239794c8f793822aa7