### PR TITLE
Add Waveshare board pinouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Ce projet fournit un squelette modulaire pour développer un firmware compatible
 Chaque composant est livré sous forme de squelette commenté en français afin de faciliter son extension.
 
 > **Note :** les pilotes et modules fournis sont des exemples à compléter pour obtenir un firmware opérationnel. Un pilote `esp_lcd` minimal pour les écrans Waveshare est fourni dans `drivers/lcd_panel_waveshare.c`.
+>
+> Les tableaux de brochage détaillés des cartes sont disponibles dans
+> [`docs/waveshare_pinout.md`](docs/waveshare_pinout.md).
 
 ## Licence
 

--- a/docs/waveshare_pinout.md
+++ b/docs/waveshare_pinout.md
@@ -1,0 +1,75 @@
+# Brochage des cartes Waveshare ESP32-S3 Touch LCD
+
+Ces tableaux r\xC3\xA9capitulent les connexions GPIO des cartes 7\" et 5B fournies par Waveshare.
+
+## ESP32-S3-Touch-LCD-7
+
+| GPIO | Fonction | Description |
+|------|----------|-------------|
+|0 | G3 | Donn\xC3\xA9es vertes 3e bit |
+|1 | R3 | Donn\xC3\xA9es rouges 3e bit |
+|2 | R4 | Donn\xC3\xA9es rouges 4e bit |
+|3 | VSYNC | Synchronisation verticale |
+|5 | DE | Activation des donn\xC3\xA9es |
+|7 | PCLK | Horloge pixel |
+|10| B7 | Donn\xC3\xA9es bleues 7e bit |
+|14| B3 | Donn\xC3\xA9es bleues 3e bit |
+|17| B6 | Donn\xC3\xA9es bleues 6e bit |
+|18| B5 | Donn\xC3\xA9es bleues 5e bit |
+|21| G7 | Donn\xC3\xA9es vertes 7e bit |
+|38| B4 | Donn\xC3\xA9es bleues 4e bit |
+|39| G2 | Donn\xC3\xA9es vertes 2e bit |
+|40| R7 | Donn\xC3\xA9es rouges 7e bit |
+|41| R6 | Donn\xC3\xA9es rouges 6e bit |
+|42| R5 | Donn\xC3\xA9es rouges 5e bit |
+|45| G4 | Donn\xC3\xA9es vertes 4e bit |
+|46| HSYNC | Synchronisation horizontale |
+|47| G6 | Donn\xC3\xA9es vertes 6e bit |
+|48| G5 | Donn\xC3\xA9es vertes 5e bit |
+
+Broches suppl\xC3\xA9mentaires :
+- **TP_IRQ** sur GPIO4
+- **TP_SDA** sur GPIO8
+- **TP_SCL** sur GPIO9
+- **TP_RST** via EXIO1
+- **DISP** via EXIO2 (contr\xC3\xB4le du r\xC3\xA9tro\xC3\xA9clairage)
+- **USB_SEL/CAN_SEL** via EXIO5
+
+## ESP32-S3-Touch-LCD-5B
+
+| GPIO | Fonction |
+|------|----------|
+|0 | G3 |
+|1 | R3 |
+|2 | R4 |
+|3 | VSYNC |
+|4 | TP_IRQ |
+|5 | DE |
+|7 | PCLK |
+|8 | TP_SDA |
+|9 | TP_SCL |
+|10| B7 |
+|14| B3 |
+|17| B6 |
+|18| B5 |
+|21| G7 |
+|38| B4 |
+|39| G2 |
+|40| R7 |
+|41| R6 |
+|42| R5 |
+|45| G4 |
+|46| HSYNC |
+|47| G6 |
+|48| G5 |
+
+Broches suppl\xC3\xA9mentaires :
+- **TP_RST** via EXIO1
+- **DISP** via EXIO2
+- **LCD_RST** via EXIO3
+- **RS485_RXD** sur GPIO43
+- **RS485_TXD** sur GPIO44
+- **CANTX** sur GPIO15
+- **CANRX** sur GPIO16
+
+Ces informations peuvent servir de r\xC3\xA9f\xC3\xA9rence pour ajuster les pilotes et la configuration selon la carte utilis\xC3\xA9e.


### PR DESCRIPTION
## Summary
- document pin assignments for ESP32-S3 Touch LCD 7" and 5B boards
- reference the new documentation from README

## Testing
- `./setup.sh` *(failed: cloning ESP-IDF interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_684355265e1483238b261c668070769b