### PR TITLE
Improve Waveshare pin mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Ce projet fournit un squelette modulaire pour développer un firmware compatible
 Chaque composant est livré sous forme de squelette commenté en français afin de faciliter son extension.
 
 > **Note :** les pilotes et modules fournis sont des exemples à compléter pour obtenir un firmware opérationnel. Un pilote `esp_lcd` minimal pour les écrans Waveshare est fourni dans `drivers/lcd_panel_waveshare.c`.
+>
+> La fiche de caractéristiques et le brochage détaillé sont disponibles dans
+> [`docs/waveshare_pinout.md`](docs/waveshare_pinout.md).
 
 ## Licence
 

--- a/docs/waveshare_pinout.md
+++ b/docs/waveshare_pinout.md
@@ -1,0 +1,83 @@
+# Brochage et caractéristiques des cartes Waveshare ESP32-S3 Touch LCD
+
+Cette page regroupe les caractéristiques principales et le brochage des modèles 7" et 5B.
+## Caractéristiques communes
+
+- Processeur double cœur Xtensa LX7 à 240 MHz
+- Wi‑Fi 2,4 GHz (802.11 b/g/n) et Bluetooth 5
+- 16 Mo de flash et 8 Mo de PSRAM
+- 512 Ko de SRAM interne et 384 Ko de ROM
+- Interfaces CAN, RS485, I²C, USB pleine vitesse et lecteur de carte TF
+## ESP32-S3-Touch-LCD-7
+Écran LCD IPS 7 pouces 800×480 avec interface tactile capacitive (GT911).
+
+| GPIO | Fonction | Description |
+|------|----------|-------------|
+|0 | G3 | Donn\xC3\xA9es vertes 3e bit |
+|1 | R3 | Donn\xC3\xA9es rouges 3e bit |
+|2 | R4 | Donn\xC3\xA9es rouges 4e bit |
+|3 | VSYNC | Synchronisation verticale |
+|5 | DE | Activation des donn\xC3\xA9es |
+|7 | PCLK | Horloge pixel |
+|10| B7 | Donn\xC3\xA9es bleues 7e bit |
+|14| B3 | Donn\xC3\xA9es bleues 3e bit |
+|17| B6 | Donn\xC3\xA9es bleues 6e bit |
+|18| B5 | Donn\xC3\xA9es bleues 5e bit |
+|21| G7 | Donn\xC3\xA9es vertes 7e bit |
+|38| B4 | Donn\xC3\xA9es bleues 4e bit |
+|39| G2 | Donn\xC3\xA9es vertes 2e bit |
+|40| R7 | Donn\xC3\xA9es rouges 7e bit |
+|41| R6 | Donn\xC3\xA9es rouges 6e bit |
+|42| R5 | Donn\xC3\xA9es rouges 5e bit |
+|45| G4 | Donn\xC3\xA9es vertes 4e bit |
+|46| HSYNC | Synchronisation horizontale |
+|47| G6 | Donn\xC3\xA9es vertes 6e bit |
+|48| G5 | Donn\xC3\xA9es vertes 5e bit |
+
+Broches suppl\xC3\xA9mentaires :
+- **TP_IRQ** sur GPIO4
+- **TP_SDA** sur GPIO8
+- **TP_SCL** sur GPIO9
+- **TP_RST** via EXIO1
+- **DISP** via EXIO2 (contr\xC3\xB4le du r\xC3\xA9tro\xC3\xA9clairage)
+- **USB_SEL/CAN_SEL** via EXIO5
+
+## ESP32-S3-Touch-LCD-5B
+Écran IPS 5 pouces (800×480 ou 1024×600) avec alimentation large 7–36 V et RTC intégré.
+
+| GPIO | Fonction |
+|------|----------|
+|0 | G3 |
+|1 | R3 |
+|2 | R4 |
+|3 | VSYNC |
+|4 | TP_IRQ |
+|5 | DE |
+|7 | PCLK |
+|8 | TP_SDA |
+|9 | TP_SCL |
+|10| B7 |
+|14| B3 |
+|17| B6 |
+|18| B5 |
+|21| G7 |
+|38| B4 |
+|39| G2 |
+|40| R7 |
+|41| R6 |
+|42| R5 |
+|45| G4 |
+|46| HSYNC |
+|47| G6 |
+|48| G5 |
+
+Broches suppl\xC3\xA9mentaires :
+- **TP_RST** via EXIO1
+- **DISP** via EXIO2
+- **LCD_RST** via EXIO3
+- **RS485_RXD** sur GPIO43
+- **RS485_TXD** sur GPIO44
+- **CANTX** sur GPIO15
+- **CANRX** sur GPIO16
+
+Ces informations peuvent servir de r\xC3\xA9f\xC3\xA9rence pour ajuster les pilotes et la configuration selon la carte utilis\xC3\xA9e.

--- a/drivers/lcd_panel_waveshare.c
+++ b/drivers/lcd_panel_waveshare.c
@@ -4,12 +4,17 @@
 #include <esp_lcd_panel_rgb.h>
 #include <esp_log.h>
 
-#define PIN_NUM_PCLK  40
-#define PIN_NUM_CS    41
-#define PIN_NUM_DE    42
-#define PIN_NUM_VSYNC 39
-#define PIN_NUM_HSYNC 38
-#define PIN_NUM_DATA0 0
+#define PIN_NUM_PCLK  7
+#define PIN_NUM_DE    5
+#define PIN_NUM_VSYNC 3
+#define PIN_NUM_HSYNC 46
+
+// Mapping 16-bit RGB565 data bus using Waveshare pinout
+static const int data_pins[16] = {
+    14, 38, 18, 17, 10,     // B3..B7
+    39, 0, 45, 48, 47, 21,  // G2..G7 (G3 on GPIO0)
+    1, 2, 42, 41, 40        // R3..R7
+};
 
 static const char *TAG = "lcd_panel";
 
@@ -26,10 +31,10 @@ esp_lcd_panel_handle_t lcd_panel_waveshare_init(int width, int height) {
         .vsync_gpio_num = PIN_NUM_VSYNC,
         .hsync_gpio_num = PIN_NUM_HSYNC,
         .data_gpio_nums = {
-            PIN_NUM_DATA0, PIN_NUM_DATA0 + 1, PIN_NUM_DATA0 + 2, PIN_NUM_DATA0 + 3,
-            PIN_NUM_DATA0 + 4, PIN_NUM_DATA0 + 5, PIN_NUM_DATA0 + 6, PIN_NUM_DATA0 + 7,
-            PIN_NUM_DATA0 + 8, PIN_NUM_DATA0 + 9, PIN_NUM_DATA0 + 10, PIN_NUM_DATA0 + 11,
-            PIN_NUM_DATA0 + 12, PIN_NUM_DATA0 + 13, PIN_NUM_DATA0 + 14, PIN_NUM_DATA0 + 15
+            data_pins[0], data_pins[1], data_pins[2], data_pins[3],
+            data_pins[4], data_pins[5], data_pins[6], data_pins[7],
+            data_pins[8], data_pins[9], data_pins[10], data_pins[11],
+            data_pins[12], data_pins[13], data_pins[14], data_pins[15]
         },
         .timings = {
             .pclk_hz = 9 * 1000 * 1000,


### PR DESCRIPTION
## Summary
- align LCD driver pins with board documentation
- mention internal SRAM/ROM in pinout reference
- note 7-inch screen features

## Testing
- `./setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_684355265e1483238b261c668070769b