### PR TITLE
Migrate SD card unmount and ADC to new APIs

### DIFF
--- a/modules/battery.c
+++ b/modules/battery.c
@@ -1,5 +1,5 @@
 #include "battery.h"
-#include <driver/adc.h>
+#include <esp_adc/adc_oneshot.h>
 #include <esp_log.h>
 
 static const char *TAG = "battery";
@@ -8,10 +8,24 @@ static const int ADC_MAX = 4095;
 static const float VBATT_MAX = 4.2f;
 static const float VBATT_MIN = 3.3f;
 
+static adc_oneshot_unit_handle_t s_adc_handle;
+
 void battery_update(void) {
-    adc1_config_width(ADC_WIDTH_BIT_12);
-    adc1_config_channel_atten(ADC1_CHANNEL_0, ADC_ATTEN_DB_11);
-    int raw = adc1_get_raw(ADC1_CHANNEL_0);
+    if (!s_adc_handle) {
+        adc_oneshot_unit_init_cfg_t init_cfg = {
+            .unit_id = ADC_UNIT_1,
+        };
+        adc_oneshot_new_unit(&init_cfg, &s_adc_handle);
+
+        adc_oneshot_chan_cfg_t chan_cfg = {
+            .bitwidth = ADC_BITWIDTH_DEFAULT,
+            .atten = ADC_ATTEN_DB_12,
+        };
+        adc_oneshot_config_channel(s_adc_handle, ADC_CHANNEL_0, &chan_cfg);
+    }
+
+    int raw = 0;
+    adc_oneshot_read(s_adc_handle, ADC_CHANNEL_0, &raw);
     float voltage = (raw / (float)ADC_MAX) * VBATT_MAX;
     if (voltage < VBATT_MIN) voltage = VBATT_MIN;
     s_battery_percent = (int)(((voltage - VBATT_MIN) / (VBATT_MAX - VBATT_MIN)) * 100);

--- a/modules/sd_card.c
+++ b/modules/sd_card.c
@@ -26,7 +26,7 @@ void sd_card_init(void) {
 
 void sd_card_unmount(void) {
     if (s_card) {
-        esp_vfs_fat_sdmmc_unmount();
+        esp_vfs_fat_sdcard_unmount("/sdcard", s_card);
         s_card = NULL;
         ESP_LOGI(TAG, "Carte SD démontée");
     }


### PR DESCRIPTION
## Summary
- update SD card unmount call to `esp_vfs_fat_sdcard_unmount`
- migrate battery measurement to ADC oneshot API

## Testing
- `idf.py --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68436a86136c832393aad8aa64405de7