### PR TITLE
Clarify environment setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,25 @@ Ce projet fournit un squelette modulaire pour développer un firmware compatible
 2. Exécuter `./setup.sh` pour préparer l'environnement (dépendances APT
    incluses).
 
-3. Initialiser l'environnement : `source $IDF_PATH/export.sh`.
-4. Compiler le projet :
+3. Initialiser l'environnement ESP‑IDF :
+   ```bash
+   source "$HOME/esp-idf/export.sh"
+   ```
+   (ou `source "$IDF_PATH/export.sh"` si la variable est déjà définie)
+4. Vérifier que `idf.py` est disponible :
+   ```bash
+   idf.py --version
+   ```
+   La commande doit renvoyer un numéro de version (ex. `ESP-IDF v6.0.0`).
+5. Compiler le projet :
    ```bash
    idf.py build
    ```
-5. Flasher sur la carte :
+6. Flasher sur la carte :
    ```bash
    idf.py -p /dev/ttyUSB0 flash monitor
    ```
-6. Le fichier `partitions.csv` définit une partition `factory` de 2 Mo. Prévoyez donc une carte avec au moins 4 Mo de flash et activez cette table via `sdkconfig.defaults`.
+7. Le fichier `partitions.csv` définit une partition `factory` de 2 Mo. Prévoyez donc une carte avec au moins 4 Mo de flash et activez cette table via `sdkconfig.defaults`.
    Si vous aviez déjà un fichier `sdkconfig` généré, exécutez `idf.py fullclean` pour prendre en compte cette nouvelle configuration.
 
 ## Architecture

--- a/components/README.md
+++ b/components/README.md
@@ -1,1 +1,7 @@
-Ce dossier contiendra LVGL une fois setup.sh exécuté.
+Ce dossier contiendra LVGL une fois `setup.sh` exécuté.
+Après l'installation, chargez l'environnement ESP‑IDF :
+```bash
+source "$HOME/esp-idf/export.sh"
+```
+(ou `source "$IDF_PATH/export.sh"` si la variable est déjà définie)
+Ceci permet d'utiliser la commande `idf.py` pour compiler le projet.

--- a/docs/waveshare_pinout.md
+++ b/docs/waveshare_pinout.md
@@ -81,3 +81,10 @@ Broches suppl\xC3\xA9mentaires :
 - **CANRX** sur GPIO16
 
 Ces informations peuvent servir de r\xC3\xA9f\xC3\xA9rence pour ajuster les pilotes et la configuration selon la carte utilis\xC3\xA9e.
+
+Pour pr\xC3\xA9parer l\x27environnement et compiler le projet, lancez d\x27abord `./setup.sh`,
+puis chargez l\x27ESP‑IDF avec :
+```bash
+source "$HOME/esp-idf/export.sh"
+```
+Reportez-vous \xC3\xA9galement au fichier [README.md](../README.md) pour plus de d\xC3\xA9tails.

--- a/setup.sh
+++ b/setup.sh
@@ -26,6 +26,13 @@ fi
 
 source "$IDF_PATH/export.sh"
 
+# Vérifie la disponibilité d'idf.py
+if ! command -v idf.py >/dev/null; then
+  echo "Erreur: idf.py introuvable. Vérifiez l'installation ESP-IDF." >&2
+  exit 1
+fi
+idf.py --version >&2
+
 # Récupère LVGL complet si absent
 if [ ! -d "components/lvgl" ]; then
   echo "Clonage de LVGL" >&2


### PR DESCRIPTION
## Summary
- refine README build instructions
- explain sourcing export script in `components/README.md`
- include setup commands in pinout documentation
- verify `idf.py` availability in `setup.sh`

## Testing
- `./setup.sh` *(fails: unexpected disconnect)*
- `idf.py --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68437eee92a08323a6311aea270b29ce