### PR TITLE
Add status in UI

### DIFF
--- a/drivers/wifi_driver.c
+++ b/drivers/wifi_driver.c
@@ -6,20 +6,24 @@
 #include <nvs.h>
 #include <string.h>
 #include <stdlib.h>
+#include <stdbool.h>
 
 static const char *TAG = "wifi";
 static esp_event_handler_instance_t s_any_id;
 static esp_event_handler_instance_t s_got_ip;
+static bool s_connected = false;
 
 static void wifi_event_handler(void *arg, esp_event_base_t base,
                                int32_t id, void *data)
 {
     if (base == WIFI_EVENT && id == WIFI_EVENT_STA_DISCONNECTED) {
         ESP_LOGW(TAG, "Déconnecté, reconnexion...");
+        s_connected = false;
         esp_wifi_connect();
     } else if (base == IP_EVENT && id == IP_EVENT_STA_GOT_IP) {
         ip_event_got_ip_t *evt = (ip_event_got_ip_t *)data;
         ESP_LOGI(TAG, "Adresse IP: " IPSTR, IP2STR(&evt->ip_info.ip));
+        s_connected = true;
     }
 }
 
@@ -103,3 +107,8 @@ esp_err_t wifi_driver_connect(const char *new_ssid, const char *new_pass) {
     }
     return err;
 }
+
+bool wifi_driver_is_connected(void) {
+    return s_connected;
+}
+

--- a/drivers/wifi_driver.h
+++ b/drivers/wifi_driver.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <esp_wifi.h>
 #include <esp_err.h>
+#include <stdbool.h>
 
 
 // Initialisation de la pile Wi-Fi
@@ -10,4 +11,7 @@ void wifi_driver_init(void);
 // Si ssid et pass ne sont pas NULL, ils sont sauvegardés en NVS.
 // Retourne ESP_OK si la connexion a réussi
 esp_err_t wifi_driver_connect(const char *ssid, const char *pass);
+
+// Retourne true si la station est connectée à un AP
+bool wifi_driver_is_connected(void);
 

--- a/modules/sd_card.c
+++ b/modules/sd_card.c
@@ -4,6 +4,7 @@
 #include <driver/sdmmc_host.h>
 #include <driver/sdmmc_defs.h>
 #include <esp_log.h>
+#include <stdbool.h>
 
 static const char *TAG = "sd";
 static sdmmc_card_t *s_card;
@@ -30,4 +31,8 @@ void sd_card_unmount(void) {
         s_card = NULL;
         ESP_LOGI(TAG, "Carte SD démontée");
     }
+}
+
+bool sd_card_is_mounted(void) {
+    return s_card != NULL;
 }

--- a/modules/sd_card.h
+++ b/modules/sd_card.h
@@ -1,4 +1,7 @@
 #pragma once
+#include <stdbool.h>
 
 // Gestion de la carte SD pour la lecture et l'écriture de fichiers
 void sd_card_init(void);
+void sd_card_unmount(void);
+bool sd_card_is_mounted(void);

--- a/ui/ui.c
+++ b/ui/ui.c
@@ -1,6 +1,8 @@
 #include "ui.h"
 #include <lvgl.h>
 #include "battery.h"
+#include "wifi_driver.h"
+#include "sd_card.h"
 #include <inttypes.h>
 
 static lv_style_t style_dark;
@@ -8,6 +10,8 @@ static lv_style_t style_dark;
 static lv_obj_t *bar_batt;
 static lv_obj_t *label_batt;
 static lv_obj_t *label_slider;
+static lv_obj_t *label_wifi;
+static lv_obj_t *label_sd;
 
 static void btn_event_cb(lv_event_t *e)
 {
@@ -26,6 +30,16 @@ static void battery_timer_cb(lv_timer_t *t)
     battery_update();
     lv_bar_set_value(bar_batt, battery_get_percent(), LV_ANIM_OFF);
     lv_label_set_text_fmt(label_batt, "%"PRId32"%%", (int32_t)battery_get_percent());
+    if (wifi_driver_is_connected()) {
+        lv_label_set_text(label_wifi, "Wi-Fi: connecté");
+    } else {
+        lv_label_set_text(label_wifi, "Wi-Fi: déconnecté");
+    }
+    if (sd_card_is_mounted()) {
+        lv_label_set_text(label_sd, "SD: montée");
+    } else {
+        lv_label_set_text(label_sd, "SD: absente");
+    }
 }
 
 void ui_init(void) {
@@ -65,8 +79,13 @@ void ui_init(void) {
     lv_bar_set_value(bar_batt, battery_get_percent(), LV_ANIM_OFF);
     label_batt = lv_label_create(cont);
     lv_label_set_text_fmt(label_batt, "%"PRId32"%%", (int32_t)battery_get_percent());
+    label_wifi = lv_label_create(cont);
+    label_sd = lv_label_create(cont);
+    lv_label_set_text(label_wifi, "Wi-Fi: ...");
+    lv_label_set_text(label_sd, "SD: ...");
 
     /* Rafraîchissement périodique du niveau batterie */
     lv_timer_create(battery_timer_cb, 2000, NULL);
+    battery_timer_cb(NULL);
 
 }


### PR DESCRIPTION
## Summary
- show Wi-Fi and SD card state on the screen
- expose helpers to query Wi-Fi and SD status

## Testing
- `./setup.sh`
- `idf.py build` *(fails: cmake process terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68438eef6f5483238a814b245a0b2890