### PR TITLE
Enable Waveshare control pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Ce projet fournit un squelette modulaire pour développer un firmware compatible
 
 Chaque composant est livré sous forme de squelette commenté en français afin de faciliter son extension.
 
-> **Note :** les pilotes et modules fournis sont des exemples à compléter pour obtenir un firmware opérationnel. Un pilote `esp_lcd` minimal pour les écrans Waveshare est fourni dans `drivers/lcd_panel_waveshare.c`.
+> **Note :** les pilotes et modules fournis sont des exemples à compléter pour obtenir un firmware opérationnel. Le pilote `drivers/lcd_panel_waveshare.c` contrôle désormais les broches `DISP` et `LCD_RST` pour allumer l'écran, mais libre à vous d'ajuster les numéros de GPIO selon votre câblage.
 >
 
 > La fiche de caractéristiques et le brochage détaillé sont disponibles dans

--- a/docs/waveshare_pinout.md
+++ b/docs/waveshare_pinout.md
@@ -80,6 +80,10 @@ Broches suppl\xC3\xA9mentaires :
 - **CANTX** sur GPIO15
 - **CANRX** sur GPIO16
 
+Le pilote `lcd_panel_waveshare.c` utilise ces signaux `DISP` et `LCD_RST` pour
+allumer l'écran lors de l'initialisation. Vous pouvez modifier les macros
+`PIN_NUM_DISP` et `PIN_NUM_LCD_RST` pour correspondre à votre câblage.
+
 Ces informations peuvent servir de r\xC3\xA9f\xC3\xA9rence pour ajuster les pilotes et la configuration selon la carte utilis\xC3\xA9e.
 
 

--- a/drivers/lcd_panel_waveshare.c
+++ b/drivers/lcd_panel_waveshare.c
@@ -3,11 +3,20 @@
 #include <esp_lcd_panel_vendor.h>
 #include <esp_lcd_panel_rgb.h>
 #include <esp_log.h>
+#include <driver/gpio.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
 #define PIN_NUM_PCLK  7
 #define PIN_NUM_DE    5
 #define PIN_NUM_VSYNC 3
 #define PIN_NUM_HSYNC 46
+#ifndef PIN_NUM_DISP
+#define PIN_NUM_DISP  -1
+#endif
+#ifndef PIN_NUM_LCD_RST
+#define PIN_NUM_LCD_RST -1
+#endif
 
 #if SOC_LCD_RGB_SUPPORTED
 // Mapping 16-bit RGB565 data bus using Waveshare pinout
@@ -22,6 +31,27 @@ static const char *TAG = "lcd_panel";
 
 esp_lcd_panel_handle_t lcd_panel_waveshare_init(int width, int height) {
 #if SOC_LCD_RGB_SUPPORTED
+
+    if (PIN_NUM_DISP >= 0) {
+        gpio_config_t conf = {
+            .pin_bit_mask = 1ULL << PIN_NUM_DISP,
+            .mode = GPIO_MODE_OUTPUT,
+        };
+        gpio_config(&conf);
+        gpio_set_level(PIN_NUM_DISP, 0);
+    }
+
+    if (PIN_NUM_LCD_RST >= 0) {
+        gpio_config_t conf = {
+            .pin_bit_mask = 1ULL << PIN_NUM_LCD_RST,
+            .mode = GPIO_MODE_OUTPUT,
+        };
+        gpio_config(&conf);
+        gpio_set_level(PIN_NUM_LCD_RST, 0);
+        vTaskDelay(pdMS_TO_TICKS(10));
+        gpio_set_level(PIN_NUM_LCD_RST, 1);
+        vTaskDelay(pdMS_TO_TICKS(10));
+    }
 
     esp_lcd_rgb_panel_config_t panel_config = {
         .data_width = 16,
@@ -54,6 +84,12 @@ esp_lcd_panel_handle_t lcd_panel_waveshare_init(int width, int height) {
     esp_lcd_panel_reset(handle);
     esp_lcd_panel_init(handle);
     esp_lcd_panel_invert_color(handle, true);
+
+    if (PIN_NUM_DISP >= 0) {
+        gpio_set_level(PIN_NUM_DISP, 1);
+    }
+
+    esp_lcd_panel_disp_on_off(handle, true);
     return handle;
 #else
     ESP_LOGW(TAG, "RGB LCD non supporté sur cette cible");

--- a/drivers/lcd_panel_waveshare.h
+++ b/drivers/lcd_panel_waveshare.h
@@ -2,5 +2,9 @@
 #include <esp_lcd_panel_ops.h>
 #include <stdint.h>
 
-// Initialise le panneau LCD Waveshare et renvoie le handle
+/*
+ * Initialise le panneau LCD Waveshare et renvoie le handle.
+ * Les broches de contrôle DISP et LCD_RST peuvent être définies via
+ * les macros PIN_NUM_DISP et PIN_NUM_LCD_RST avant la compilation.
+ */
 esp_lcd_panel_handle_t lcd_panel_waveshare_init(int width, int height);


### PR DESCRIPTION
## Summary
- handle DISP and LCD_RST pins in the Waveshare LCD driver
- document the macros used to define these pins
- mention DISP/LCD_RST in README
- update pinout doc about driver usage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68440b764c18832394fc4b3b4881a8ec