### PR TITLE
Set Waveshare control pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Ce projet fournit un squelette modulaire pour développer un firmware compatible
 Chaque composant est livré sous forme de squelette commenté en français afin de faciliter son extension.
 
 > **Note :** les pilotes et modules fournis sont des exemples à compléter pour obtenir un firmware opérationnel. Le pilote `drivers/lcd_panel_waveshare.c` utilise la table de brochage définie dans `drivers/waveshare_pins.h` et contrôle optionnellement les broches `DISP` et `LCD_RST`. Ajustez ces numéros via les macros `PIN_NUM_DISP` et `PIN_NUM_LCD_RST` (valeur `-1` pour ignorer la broche) selon votre câblage.
+> Dans la configuration actuelle, `PIN_NUM_DISP` vaut `6` et `PIN_NUM_LCD_RST` vaut `11`.
 >
 
 

--- a/docs/waveshare_pinout.md
+++ b/docs/waveshare_pinout.md
@@ -83,7 +83,8 @@ Broches suppl\xC3\xA9mentaires :
 Le pilote `lcd_panel_waveshare.c` s'appuie sur les définitions de `drivers/waveshare_pins.h`.
 Les signaux `DISP` et `LCD_RST` peuvent être activés via ces macros et
 modifiés à l'aide de `PIN_NUM_DISP` et `PIN_NUM_LCD_RST` pour correspondre à votre câblage,
-ou laissés à `-1` afin d'ignorer ces broches.
+ou laissés à `-1` afin d'ignorer ces broches. Dans ce projet, `PIN_NUM_DISP` vaut `6`
+et `PIN_NUM_LCD_RST` vaut `11`, valeurs adaptées au modèle 5B.
 
 Ces informations peuvent servir de r\xC3\xA9f\xC3\xA9rence pour ajuster les pilotes et la configuration selon la carte utilis\xC3\xA9e.
 

--- a/drivers/waveshare_pins.h
+++ b/drivers/waveshare_pins.h
@@ -28,8 +28,8 @@
 
 /* Optional control pins. Set to -1 if unconnected */
 #ifndef PIN_NUM_DISP
-#define PIN_NUM_DISP    -1
+#define PIN_NUM_DISP    6
 #endif
 #ifndef PIN_NUM_LCD_RST
-#define PIN_NUM_LCD_RST -1
+#define PIN_NUM_LCD_RST 11
 #endif


### PR DESCRIPTION
## Summary
- set default DISP and LCD_RST pins in `waveshare_pins.h`
- document default pins in README and pinout doc



------
https://chatgpt.com/codex/tasks/task_e_6844401e16348323a375e26806832eec