### PR TITLE
Fix SPI_MODE0 build error

### DIFF
--- a/drivers/lcd_panel_waveshare.c
+++ b/drivers/lcd_panel_waveshare.c
@@ -6,6 +6,9 @@
 #include "st7701.h"
 #include <driver/spi_master.h>
 #include <driver/spi_common.h>
+#ifndef SPI_MODE0
+#define SPI_MODE0 0
+#endif
 #include <esp_log.h>
 #include <driver/gpio.h>
 #include <esp_bit_defs.h>


### PR DESCRIPTION
## Summary
- define `SPI_MODE0` macro when missing to fix build for Waveshare display

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68447b7fad6c8323b19f61ca0370b61d