### PR TITLE
Update docs with timing auto-configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ Chaque composant est livré sous forme de squelette commenté en français afin 
 
 > **Note :** les pilotes et modules fournis sont des exemples à compléter pour obtenir un firmware opérationnel. Le pilote `drivers/lcd_panel_waveshare.c` utilise la table de brochage définie dans `drivers/waveshare_pins.h` et contrôle optionnellement les broches `DISP` et `LCD_RST`. Ajustez ces numéros via les macros `PIN_NUM_DISP` et `PIN_NUM_LCD_RST` (valeur `-1` pour ignorer la broche) selon votre câblage.
 > Dans la configuration actuelle, `PIN_NUM_DISP` vaut `6` et `PIN_NUM_LCD_RST` vaut `11`.
+> Depuis la version actuelle, ce pilote règle également automatiquement la fréquence
+> `pclk` et les temporisations de synchronisation selon la résolution détectée (800×480
+> ou 1024×600). Pensez à mettre à jour vos sources avant de compiler.
 >
 
 

--- a/docs/waveshare_pinout.md
+++ b/docs/waveshare_pinout.md
@@ -86,6 +86,12 @@ modifiés à l'aide de `PIN_NUM_DISP` et `PIN_NUM_LCD_RST` pour correspondre à 
 ou laissés à `-1` afin d'ignorer ces broches. Dans ce projet, `PIN_NUM_DISP` vaut `6`
 et `PIN_NUM_LCD_RST` vaut `11`, valeurs adaptées au modèle 5B.
 
+Depuis la mise à jour du pilote `lcd_panel_waveshare.c`, la fréquence `pclk` et
+les temporisations de synchronisation (fronts et retards HSYNC/VSYNC) sont
+déterminées automatiquement selon la résolution détectée (800×480 ou 1024×600).
+Veillez donc à compiler avec la dernière version des sources pour bénéficier de
+ces réglages.
+
 Ces informations peuvent servir de r\xC3\xA9f\xC3\xA9rence pour ajuster les pilotes et la configuration selon la carte utilis\xC3\xA9e.
 
 


### PR DESCRIPTION
## Summary
- mention automatic timing in README
- document the new `pclk` and sync timing behaviour in Waveshare pinout docs

## Testing
- `./setup.sh`
- `idf.py build` *(fails: git submodules not cloned before interruption)*

------
https://chatgpt.com/codex/tasks/task_e_6844863af61c83239ba1fb2792d216c2