### PR TITLE
docs: add schedule guidelines for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,3 +12,11 @@
 - **Agent d’Observabilité & Monitoring (Observer)** : agrège logs et métriques pour faciliter le diagnostic.
 - **Agent de Documentation & Assistance (DocAgent)** : génère et maintient la documentation, y compris ce fichier.
 - **Agent de Collaboration (CollabAgent)** : facilite la gestion de branches et tickets et suit l'avancement global.
+
+## Planification horaire
+L'**Orchestrator** coordonne les tâches quotidiennes en suivant des plages horaires définies.
+Chaque matin, le **Provisioner** vérifie le setup et la disponibilité des outils.
+Le **Builder** déclenche des compilations régulières au fil de la journée.
+Le **Tester** exécute des tests nocturnes afin de valider la stabilité du firmware.
+Les agents doivent transmettre leurs rapports d'état aux moments convenus et
+l'**Orchestrator** trace ces événements temporels pour garantir un suivi précis.


### PR DESCRIPTION
## Summary
- document new section "Planification horaire" to outline daily scheduling by the Orchestrator

## Testing
- `pre-commit` *(fails: not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68448accd4bc8323a42729c99d9006ff