### PR TITLE
Add orchestration scripts for setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,8 +3,8 @@
 
 
 ## Agents spécialisés
-- **Agent Orchestrateur Principal (Orchestrator)** : pilote l'écosystème, planifie les tâches et coordonne les autres agents.
-- **Agent de Provisioning & Setup (Provisioner)** : installe et met à jour les outils de développement et vérifie la disponibilité de l'ESP‑IDF.
+- **Agent Orchestrateur Principal (Orchestrator)** : pilote l'écosystème, planifie les tâches et coordonne les autres agents via `tools/orchestrator.py`.
+- **Agent de Provisioning & Setup (Provisioner)** : installe et met à jour les outils de développement et vérifie la disponibilité de l'ESP‑IDF à l'aide de `tools/provisioner.py` qui exécute `setup.sh` si besoin.
 - **Agents de Développement Par Langage (DevAgent[Lang])** : fournissent l'expertise pour chaque technologie et proposent de bonnes pratiques.
 - **Agent Build & CI (Builder)** : centralise la compilation et la CI/CD en appliquant les options de `sdkconfig.defaults`.
 - **Agent de Test & Qualité (Tester)** : automatise les tests et le lint pour garantir un firmware stable.
@@ -15,7 +15,7 @@
 
 ## Planification horaire
 L'**Orchestrator** coordonne les tâches quotidiennes en suivant des plages horaires définies.
-Chaque matin, le **Provisioner** vérifie le setup et la disponibilité des outils.
+Chaque matin, il lance `tools/provisioner.py` pour que le **Provisioner** vérifie le setup et exécute `setup.sh` si nécessaire.
 Le **Builder** déclenche des compilations régulières au fil de la journée.
 Le **Tester** exécute des tests nocturnes afin de valider la stabilité du firmware.
 Les agents doivent transmettre leurs rapports d'état aux moments convenus et

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Ce projet fournit un squelette modulaire pour développer un firmware compatible
 ## Compilation et flashage
 
 1. Installer l'ESP-IDF conformément à la documentation officielle.
-2. Exécuter `./setup.sh` pour préparer l'environnement (dépendances APT
-   incluses).
+2. Lancer `python3 tools/orchestrator.py` pour préparer l'environnement via le
+   Provisioner (ou exécuter `./setup.sh` manuellement).
 
 
 3. Initialiser l'environnement ESP‑IDF :
@@ -47,7 +47,8 @@ Ce projet fournit un squelette modulaire pour développer un firmware compatible
 - `battery.c` utilise l'API ADC *oneshot* avec une atténuation `ADC_ATTEN_DB_12`.
 - `sd_card.c` démonte la carte avec `esp_vfs_fat_sdcard_unmount("/sdcard")`.
 - `ui/` : interface graphique LVGL adaptative.
-- `components/` : contient LVGL après exécution de `./setup.sh`.
+- `components/` : contient LVGL une fois la Provision exécutée (via
+  `tools/orchestrator.py`).
 
 Chaque composant est livré sous forme de squelette commenté en français afin de faciliter son extension.
 

--- a/docs/waveshare_pinout.md
+++ b/docs/waveshare_pinout.md
@@ -96,7 +96,7 @@ Ces informations peuvent servir de r\xC3\xA9f\xC3\xA9rence pour ajuster les pilo
 
 
 
-Pour pr\xC3\xA9parer l\x27environnement et compiler le projet, lancez d\x27abord `./setup.sh`,
+Pour pr\xC3\xA9parer l\x27environnement et compiler le projet, ex\xC3\xA9cutez `python3 tools/orchestrator.py` (ou `./setup.sh`),
 puis chargez l\x27ESP‑IDF avec :
 
 source "$HOME/esp-idf/export.sh"

--- a/tools/orchestrator.py
+++ b/tools/orchestrator.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Orchestrator entry point triggering the Provisioner."""
+import subprocess
+from pathlib import Path
+import sys
+
+PROVISIONER = Path(__file__).with_name("provisioner.py")
+
+
+def main() -> None:
+    result = subprocess.run([sys.executable, str(PROVISIONER)])
+    sys.exit(result.returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/provisioner.py
+++ b/tools/provisioner.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Provisioner script to ensure ESP-IDF setup is ready."""
+import os
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SETUP = ROOT / "setup.sh"
+
+
+def need_setup() -> bool:
+    lvgl_dir = ROOT / "components" / "lvgl"
+    if not lvgl_dir.exists():
+        return True
+    if "IDF_PATH" not in os.environ:
+        return True
+    try:
+        subprocess.run(["idf.py", "--version"], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return True
+    return False
+
+
+def run_setup() -> None:
+    subprocess.check_call(["bash", str(SETUP)])
+
+
+def main() -> None:
+    if need_setup():
+        print("[Provisioner] Running setup.sh", flush=True)
+        run_setup()
+    else:
+        print("[Provisioner] Environment already prepared", flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- automate environment provisioning via a new Orchestrator script
- call setup.sh from a Provisioner script when needed
- document the new workflow in README and docs
- mention scripts in AGENTS description

## Testing
- `python3 -m py_compile tools/orchestrator.py tools/provisioner.py`

------
https://chatgpt.com/codex/tasks/task_e_68448b989cd08323b8e412e29f72853e