### PR TITLE
Refine setup script with version options

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,13 @@ Ce projet fournit un squelette modulaire pour développer un firmware compatible
 
 1. Installer l'ESP-IDF conformément à la documentation officielle.
 2. Lancer `python3 tools/orchestrator.py` pour préparer l'environnement via le
-   Provisioner (ou exécuter `./setup.sh` manuellement).
+   Provisioner (ou exécuter `./setup.sh` manuellement). Ce script télécharge
+   l'ESP‑IDF complet et peut prendre plusieurs minutes. Définissez la variable
+   `IDF_VERSION` pour choisir une version spécifique :
 
+   ```bash
+   IDF_VERSION=v6.0 ./setup.sh
+   ```
 
 3. Initialiser l'environnement ESP‑IDF :
    ```bash

--- a/components/README.md
+++ b/components/README.md
@@ -1,4 +1,5 @@
-Ce dossier contiendra LVGL une fois `setup.sh` exécuté.
+Ce dossier contiendra LVGL une fois `setup.sh` exécuté. La variable `LVGL_TAG`
+permet de choisir la version souhaitée lors de l'installation.
 
 Après l'installation, chargez l'environnement ESP‑IDF :
 

--- a/docs/waveshare_pinout.md
+++ b/docs/waveshare_pinout.md
@@ -96,8 +96,13 @@ Ces informations peuvent servir de r\xC3\xA9f\xC3\xA9rence pour ajuster les pilo
 
 
 
-Pour pr\xC3\xA9parer l\x27environnement et compiler le projet, ex\xC3\xA9cutez `python3 tools/orchestrator.py` (ou `./setup.sh`),
-puis chargez l\x27ESP‑IDF avec :
+Pour préparer l'environnement et compiler le projet, exécutez `python3 tools/orchestrator.py` (ou `./setup.sh`).
+Ce script télécharge l'ESP‑IDF complet ainsi que les outils de compilation et peut prendre un certain temps. Vous pouvez définir `IDF_VERSION` pour choisir la branche ou le tag désiré avant l'exécution :
+
+```bash
+IDF_VERSION=v6.0 ./setup.sh
+```
+Ensuite, chargez l'ESP‑IDF avec:
 
 source "$HOME/esp-idf/export.sh"
 


### PR DESCRIPTION
## Summary
- make setup.sh configurable with `IDF_VERSION` and `LVGL_TAG`
- avoid SSL overrides and add basic package manager checks
- document how to select the ESP-IDF version in README and docs
- mention LVGL_TAG in component README

## Testing
- `python3 -m py_compile tools/orchestrator.py tools/provisioner.py`


------
https://chatgpt.com/codex/tasks/task_e_684499fd727c832392670cb9a4fcffd7