### PR TITLE
Update default ESP-IDF version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Ce projet fournit un squelette modulaire pour développer un firmware compatible
    `IDF_VERSION` pour choisir une version spécifique :
 
    ```bash
-   IDF_VERSION=v6.0 ./setup.sh
+   IDF_VERSION=v5.1.2 ./setup.sh
    ```
 
 3. Initialiser l'environnement ESP‑IDF :
@@ -24,7 +24,7 @@ Ce projet fournit un squelette modulaire pour développer un firmware compatible
    ```bash
    idf.py --version
    ```
-   La commande doit renvoyer un numéro de version (ex. `ESP-IDF v6.0.0`).
+   La commande doit renvoyer un numéro de version (ex. `ESP-IDF v5.1.2`).
 5. Compiler le projet :
    ```bash
    idf.py build

--- a/docs/waveshare_pinout.md
+++ b/docs/waveshare_pinout.md
@@ -100,7 +100,7 @@ Pour préparer l'environnement et compiler le projet, exécutez `python3 tools/o
 Ce script télécharge l'ESP‑IDF complet ainsi que les outils de compilation et peut prendre un certain temps. Vous pouvez définir `IDF_VERSION` pour choisir la branche ou le tag désiré avant l'exécution :
 
 ```bash
-IDF_VERSION=v6.0 ./setup.sh
+IDF_VERSION=v5.1.2 ./setup.sh
 ```
 Ensuite, chargez l'ESP‑IDF avec:
 

--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Permet de choisir la version d'ESP-IDF et celle de LVGL via des variables
-IDF_VERSION="${IDF_VERSION:-v6.0}"
+IDF_VERSION="${IDF_VERSION:-v5.1.2}"
 IDF_PATH="${IDF_PATH:-$HOME/esp-idf}"
 LVGL_TAG="${LVGL_TAG:-v8.3.0}"
 


### PR DESCRIPTION
## Summary
- set default IDF_VERSION in `setup.sh` to `v5.1.2`
- update docs to show `IDF_VERSION=v5.1.2`

## Testing
- `bash setup.sh` *(fails: Certificate verify failed)*

------
https://chatgpt.com/codex/tasks/task_e_6844a5575a448323988c0c856e80ceec